### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/planner/pom.xml
+++ b/planner/pom.xml
@@ -49,7 +49,7 @@
 				<version>2.16</version>
 				<configuration>
 					<reuseForks>false</reuseForks>
-					<forkCount>1</forkCount>
+					<forkCount>1.5C</forkCount>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
